### PR TITLE
(GH-1) Added .Wait to ensure Tasks return correctly

### DIFF
--- a/Cake.AppVeyor/Aliases.cs
+++ b/Cake.AppVeyor/Aliases.cs
@@ -24,7 +24,7 @@ namespace Cake.AppVeyor
         public static void AppVeyorClearCache(this ICakeContext context, AppVeyorSettings settings, string accountName, string projectSlug)
         {
             var appVeyor = AppVeyorClient.Create(settings.ApiToken);
-            appVeyor.ClearCache (accountName, projectSlug);
+            appVeyor.ClearCache (accountName, projectSlug).Wait();
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Cake.AppVeyor
         public static void AppVeyorClearCache(this ICakeContext context, string appVeyorApiToken, string accountName, string projectSlug)
         {
             var appVeyor = AppVeyorClient.Create(appVeyorApiToken);
-            appVeyor.ClearCache (accountName, projectSlug);
+            appVeyor.ClearCache (accountName, projectSlug).Wait();
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace Cake.AppVeyor
         }
 
         /// <summary>
-        /// Gets the last build on the specified branch of the project 
+        /// Gets the last build on the specified branch of the project
         /// </summary>
         /// <returns>The project's last successful build on the branch.</returns>
         /// <param name="context">The context.</param>
@@ -292,7 +292,7 @@ namespace Cake.AppVeyor
         public static void AppVeyorCancelBuild (this ICakeContext context, string appVeyorApiToken, string accountName, string projectSlug, string buildVersion)
         {
             var appVeyor = AppVeyorClient.Create (appVeyorApiToken);
-            appVeyor.CancelBuild (accountName, projectSlug, buildVersion);
+            appVeyor.CancelBuild (accountName, projectSlug, buildVersion).Wait();
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace Cake.AppVeyor
             var appVeyor = AppVeyorClient.Create (appVeyorApiToken);
             appVeyor.CancelDeployment (new AppVeyorCancelDeploymentRequest {
                 DeploymentId = deploymentId
-            });
+            }).Wait();
         }
 
         /// <summary>


### PR DESCRIPTION
@Redth  After doing some more testing with this new Alias, it turns out that it didn't work :-(

It wasn't working due to the fact that the Task wasn't being waited on, and as a result, the request was never being sent out.  I noticed that all other methods were using `.Result` but because there is nothing returned from the DELETE methods, this wasn't available.  Instead, using `.Wait` had the desired result.

I have done some testing, and I can confirm that these aliases now work as expected.